### PR TITLE
Java 7 compat with non-internal API

### DIFF
--- a/src/main/java/doc/xml/DocReader.java
+++ b/src/main/java/doc/xml/DocReader.java
@@ -46,7 +46,7 @@ import doc.mathobjects.RegularPolygonObject;
 import doc.mathobjects.TextObject;
 import doc.mathobjects.VariableValueInsertionProblem;
 
-import sun.misc.BASE64Decoder;
+import javax.xml.bind.DatatypeConverter;
 
 public class DocReader extends DefaultHandler {
 
@@ -96,9 +96,8 @@ public class DocReader extends DefaultHandler {
 	}
 	
 	public Document readServerDoc(String doc, String docName) throws SAXException, IOException{
-		BASE64Decoder decoder = new BASE64Decoder();
-		ByteBuffer data = decoder.decodeBufferToByteBuffer(doc);
-		ByteArrayInputStream inputStream = new ByteArrayInputStream(data.array());
+		byte[] docBytes = DatatypeConverter.parseBase64Binary(doc);
+		ByteArrayInputStream inputStream = new ByteArrayInputStream(docBytes);
 		InputStreamReader reader = new InputStreamReader(inputStream);
 		return readDoc(reader, docName);
 	}

--- a/src/main/java/doc_gui/ObjectToolBar.java
+++ b/src/main/java/doc_gui/ObjectToolBar.java
@@ -27,8 +27,6 @@ import javax.swing.JToolBar;
 
 import org.xml.sax.SAXException;
 
-import com.sun.org.apache.bcel.internal.generic.NEW;
-
 import doc.mathobjects.MathObject;
 
 public class ObjectToolBar extends JToolBar {


### PR DESCRIPTION
I replaced the `com.sun` base64 with the xml package decoder and removed an unused import of an internal API in another file.

compiles with Java 1.7. We could probably push it down do 1.6 if we remove the diamond Operators.
But since even 1.7 is no longer supported it might not be worth it.